### PR TITLE
Under recent versions of SML/NJ, Position.int and Int.int are not equal types

### DIFF
--- a/src/tools/mc/match-comp/match-check.sml
+++ b/src/tools/mc/match-comp/match-check.sml
@@ -158,7 +158,7 @@ structure MatchCheck (* : sig
 (* error handling *)
   type err_stream = MatchErrors.err_stream
 
-  val bogusLocation = (0,0) (* FIXME *)
+  val bogusLocation = (Position.fromInt 0, Position.fromInt 0) (* FIXME *)
 
   fun errRedundant errStrm msg = 
     (TextIO.print (msg ^ "\n");

--- a/src/tools/mc/parser/bom.grm
+++ b/src/tools/mc/parser/bom.grm
@@ -128,12 +128,14 @@
     ret_val
   end (* new_label() *)
 
-  val listTyTerm = BPT.T_TyCon {tree = ([Atom.atom "List"], Op.list), span = (0, 0)}
+  val spanZZ = (Position.fromInt 0, Position.fromInt 0)
+
+  val listTyTerm = BPT.T_TyCon {tree = ([Atom.atom "List"], Op.list), span = spanZZ}
 
   val nilPat = BPT.RW_Const((Literal.Enum(Word.fromInt 0), listTyTerm))
-  val listCons = {tree = ([Atom.atom "List"], Op.listCons'), span = (0, 0)}
+  val listCons = {tree = ([Atom.atom "List"], Op.listCons'), span = spanZZ}
 
-  val trueID = {tree = ([] : Atom.atom list, Op.boolTrue), span = (0, 0)}
+  val trueID = {tree = ([] : Atom.atom list, Op.boolTrue), span = spanZZ}
   val trueVar = BPT.SE_Var trueID
   fun mkTrueCheck se =
       [se, trueVar]

--- a/src/tools/mc/parser/sml.grm
+++ b/src/tools/mc/parser/sml.grm
@@ -94,7 +94,8 @@
 (* apply a mark constructor to a span and a tree *)
   fun mark cons (span : AntlrStreamPos.span, tr) = cons{span = span, tree = tr}
 
-  val nilID = {tree = ([] : Atom.atom list, Op.listNil), span = (0, 0)}
+  val spanZZ = (Position.fromInt 0, Position.fromInt 0)
+  val nilID = {tree = ([] : Atom.atom list, Op.listNil), span = spanZZ}
 
 (* specialize mark functions for common node types *)
   val markDecl = mark PT.MarkDecl


### PR DESCRIPTION
Under recent versions of SML/NJ, `Position.int` and `Int.int` are not equal types.